### PR TITLE
feat: implement printer management CLI commands

### DIFF
--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -134,7 +134,9 @@ fn test_get_printer() {
         "access123".to_string(),
     );
 
-    app_config.add_printer("test_printer".to_string(), printer_config).unwrap();
+    app_config
+        .add_printer("test_printer".to_string(), printer_config)
+        .unwrap();
 
     // Get existing printer
     let retrieved = app_config.get_printer("test_printer").unwrap();
@@ -165,13 +167,17 @@ fn test_default_printer_operations() {
     assert!(app_config.get_default_printer().is_err());
 
     // Add first printer
-    app_config.add_printer("printer1".to_string(), printer1).unwrap();
+    app_config
+        .add_printer("printer1".to_string(), printer1)
+        .unwrap();
     let default = app_config.get_default_printer().unwrap();
     assert_eq!(default.name, "printer1");
 
     // Add second printer
-    app_config.add_printer("printer2".to_string(), printer2).unwrap();
-    
+    app_config
+        .add_printer("printer2".to_string(), printer2)
+        .unwrap();
+
     // Set new default
     assert!(app_config.set_default_printer("printer2").is_ok());
     let default = app_config.get_default_printer().unwrap();
@@ -184,7 +190,7 @@ fn test_default_printer_operations() {
 #[test]
 fn test_list_printers() {
     let mut app_config = AppConfig::default();
-    
+
     // Empty list
     let printers = app_config.list_printers();
     assert!(printers.is_empty());
@@ -203,12 +209,16 @@ fn test_list_printers() {
         "access2".to_string(),
     );
 
-    app_config.add_printer("printer1".to_string(), printer1).unwrap();
-    app_config.add_printer("printer2".to_string(), printer2).unwrap();
+    app_config
+        .add_printer("printer1".to_string(), printer1)
+        .unwrap();
+    app_config
+        .add_printer("printer2".to_string(), printer2)
+        .unwrap();
 
     let printers = app_config.list_printers();
     assert_eq!(printers.len(), 2);
-    
+
     let names: Vec<&String> = printers.iter().map(|(name, _)| *name).collect();
     assert!(names.contains(&&"printer1".to_string()));
     assert!(names.contains(&&"printer2".to_string()));
@@ -225,7 +235,7 @@ fn test_config_path() {
 fn test_load_nonexistent_config() {
     let temp_dir = tempdir().unwrap();
     let nonexistent_path = temp_dir.path().join("nonexistent.json");
-    
+
     // Should return default config for non-existent file
     let config = AppConfig::load_from_file(&nonexistent_path).unwrap();
     assert!(config.printers.is_empty());
@@ -241,9 +251,13 @@ fn test_error_conditions() {
         "access123".to_string(),
     );
 
-    // Test PrinterExists error  
-    app_config.add_printer("test_printer".to_string(), printer_config.clone()).unwrap();
-    let err = app_config.add_printer("test_printer".to_string(), printer_config).unwrap_err();
+    // Test PrinterExists error
+    app_config
+        .add_printer("test_printer".to_string(), printer_config.clone())
+        .unwrap();
+    let err = app_config
+        .add_printer("test_printer".to_string(), printer_config)
+        .unwrap_err();
     assert!(matches!(err, ConfigError::PrinterExists(_)));
 
     // Test PrinterNotFound error

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,40 @@ enum Commands {
         #[arg(short, long)]
         access_code: String,
     },
+    /// Add a new printer configuration
+    Add {
+        /// Printer name (unique identifier)
+        #[arg(short, long)]
+        name: String,
+
+        /// Printer IP address
+        #[arg(short = 'i', long)]
+        ip: String,
+
+        /// Device ID of the printer
+        #[arg(short, long)]
+        device_id: String,
+
+        /// LAN access code for the printer
+        #[arg(short, long)]
+        access_code: String,
+
+        /// Set as default printer
+        #[arg(long)]
+        set_default: bool,
+    },
+    /// List all configured printers
+    List,
+    /// Remove a printer configuration
+    Remove {
+        /// Name of the printer to remove
+        name: String,
+    },
+    /// Set the default printer
+    SetDefault {
+        /// Name of the printer to set as default
+        name: String,
+    },
 }
 
 #[tokio::main]
@@ -51,10 +85,202 @@ async fn main() {
                 Err(e) => eprintln!("Error monitoring printer: {e}"),
             }
         }
+        Some(Commands::Add {
+            name,
+            ip,
+            device_id,
+            access_code,
+            set_default,
+        }) => {
+            if let Err(e) = handle_add_printer(name, ip, device_id, access_code, *set_default) {
+                eprintln!("Error adding printer: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::List) => {
+            if let Err(e) = handle_list_printers() {
+                eprintln!("Error listing printers: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Remove { name }) => {
+            if let Err(e) = handle_remove_printer(name) {
+                eprintln!("Error removing printer: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::SetDefault { name }) => {
+            if let Err(e) = handle_set_default_printer(name) {
+                eprintln!("Error setting default printer: {e}");
+                std::process::exit(1);
+            }
+        }
         None => {
             println!("Welcome to PulsePrint-CLI! Use --help for usage.");
         }
     }
+}
+
+fn handle_add_printer(
+    name: &str,
+    ip: &str,
+    device_id: &str,
+    access_code: &str,
+    set_default: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate inputs
+    validate_ip_address(ip)?;
+    validate_device_id(device_id)?;
+    validate_access_code(access_code)?;
+
+    // Load existing config
+    let config_path = config::AppConfig::get_config_path();
+    let mut app_config = config::AppConfig::load_from_file(&config_path)?;
+
+    // Create printer config
+    let printer_config = config::PrinterConfig::new(
+        name.to_string(),
+        ip.to_string(),
+        device_id.to_string(),
+        access_code.to_string(),
+    );
+
+    // Add printer
+    app_config.add_printer(name.to_string(), printer_config)?;
+
+    // Set as default if requested
+    if set_default {
+        app_config.set_default_printer(name)?;
+    }
+
+    // Save config
+    app_config.save_to_file(&config_path)?;
+
+    println!("✅ Printer '{name}' added successfully");
+    if set_default {
+        println!("🎯 Set as default printer");
+    }
+
+    Ok(())
+}
+
+fn handle_list_printers() -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = config::AppConfig::get_config_path();
+    let app_config = config::AppConfig::load_from_file(&config_path)?;
+
+    if app_config.printers.is_empty() {
+        println!("No printers configured. Use 'add' command to add a printer.");
+        return Ok(());
+    }
+
+    println!("Configured Printers:");
+    println!("==================");
+
+    let default_name = app_config.default_printer.as_ref();
+    let mut printers: Vec<_> = app_config.list_printers();
+    printers.sort_by_key(|(name, _)| name.as_str());
+
+    for (name, printer) in printers {
+        let default_marker = if Some(name) == default_name {
+            " (default)"
+        } else {
+            ""
+        };
+
+        println!("📄 {name}{default_marker}");
+        println!("   IP: {}", printer.ip);
+        println!("   Device ID: {}", printer.device_id);
+        println!(
+            "   Port: {} (TLS: {})",
+            printer.port,
+            if printer.use_tls {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
+        if let Some(model) = &printer.model {
+            println!("   Model: {model}");
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+fn handle_remove_printer(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = config::AppConfig::get_config_path();
+    let mut app_config = config::AppConfig::load_from_file(&config_path)?;
+
+    // Remove printer
+    let removed_printer = app_config.remove_printer(name)?;
+
+    // Save config
+    app_config.save_to_file(&config_path)?;
+
+    let removed_name = &removed_printer.name;
+    println!("🗑️  Printer '{removed_name}' removed successfully");
+
+    // Show message if this was the default printer
+    if app_config.default_printer.is_none() && !app_config.printers.is_empty() {
+        let first_printer = app_config.printers.keys().next().unwrap();
+        println!("💡 Consider setting a new default printer with: set-default {first_printer}");
+    }
+
+    Ok(())
+}
+
+fn handle_set_default_printer(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = config::AppConfig::get_config_path();
+    let mut app_config = config::AppConfig::load_from_file(&config_path)?;
+
+    // Set default printer
+    app_config.set_default_printer(name)?;
+
+    // Save config
+    app_config.save_to_file(&config_path)?;
+
+    println!("🎯 Printer '{name}' set as default");
+
+    Ok(())
+}
+
+fn validate_ip_address(ip: &str) -> Result<(), Box<dyn std::error::Error>> {
+    use std::net::Ipv4Addr;
+
+    ip.parse::<Ipv4Addr>()
+        .map_err(|_| format!("Invalid IP address: {ip}"))?;
+
+    Ok(())
+}
+
+fn validate_device_id(device_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if device_id.is_empty() {
+        return Err("Device ID cannot be empty".into());
+    }
+
+    if device_id.len() < 5 {
+        return Err("Device ID seems too short (should be like '01S00A000000000')".into());
+    }
+
+    Ok(())
+}
+
+fn validate_access_code(access_code: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if access_code.is_empty() {
+        return Err("Access code cannot be empty".into());
+    }
+
+    if access_code.len() != 8 {
+        return Err("Access code should be exactly 8 characters".into());
+    }
+
+    // Check if it's all digits
+    if !access_code.chars().all(|c| c.is_ascii_digit()) {
+        return Err("Access code should contain only digits".into());
+    }
+
+    Ok(())
 }
 
 async fn monitor_printer(config: config::PrinterConfig) -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use tempfile::tempdir;
 
 #[test]
 fn test_cli_help_command() {
@@ -58,3 +59,182 @@ fn test_monitor_missing_arguments() {
 
 // Note: Skipping actual connection test to avoid hanging
 // In a real environment, you would test with a mock MQTT broker
+
+#[test]
+fn test_cli_help_shows_new_commands() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("add"));
+    assert!(stdout.contains("list"));
+    assert!(stdout.contains("remove"));
+    assert!(stdout.contains("set-default"));
+}
+
+#[test]
+fn test_add_command_help() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "add", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("Add a new printer configuration"));
+    assert!(stdout.contains("--name"));
+    assert!(stdout.contains("--ip"));
+    assert!(stdout.contains("--device-id"));
+    assert!(stdout.contains("--access-code"));
+    assert!(stdout.contains("--set-default"));
+}
+
+#[test]
+fn test_list_command_help() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "list", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("List all configured printers"));
+}
+
+#[test]
+fn test_remove_command_help() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "remove", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("Remove a printer configuration"));
+}
+
+#[test]
+fn test_set_default_command_help() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "set-default", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("Set the default printer"));
+}
+
+#[test]
+fn test_list_empty_printers() {
+    // Set a temporary config directory to isolate this test
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+
+    let output = Command::new("cargo")
+        .args(&["run", "--", "list"])
+        .env("HOME", temp_dir.path()) // This won't work cross-platform, but good for basic testing
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+    assert!(stdout.contains("No printers configured"));
+}
+
+#[test]
+fn test_add_command_validation_invalid_ip() {
+    let output = Command::new("cargo")
+        .args(&[
+            "run",
+            "--",
+            "add",
+            "--name",
+            "test",
+            "--ip",
+            "999.999.999.999",
+            "--device-id",
+            "01S00A000000000",
+            "--access-code",
+            "12345678",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("Invalid IP address"));
+}
+
+#[test]
+fn test_add_command_validation_invalid_access_code() {
+    let output = Command::new("cargo")
+        .args(&[
+            "run",
+            "--",
+            "add",
+            "--name",
+            "test",
+            "--ip",
+            "192.168.1.100",
+            "--device-id",
+            "01S00A000000000",
+            "--access-code",
+            "123",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("Access code should be exactly 8 characters"));
+}
+
+#[test]
+fn test_add_command_missing_arguments() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "add", "--name", "test"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("required arguments were not provided"));
+}
+
+#[test]
+fn test_remove_nonexistent_printer() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "remove", "nonexistent"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("Printer not found"));
+}
+
+#[test]
+fn test_set_default_nonexistent_printer() {
+    let output = Command::new("cargo")
+        .args(&["run", "--", "set-default", "nonexistent"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("Printer not found"));
+}


### PR DESCRIPTION
## Summary
This PR implements issue #5 with comprehensive printer management CLI commands:

• **add**: Add new printer configurations with IP address and access code validation
• **list**: Display all configured printers with default indicators  
• **remove**: Delete printer configurations with helpful suggestions
• **set-default**: Set default printer for operations

## Key Features
• Input validation for IP addresses, device IDs, and access codes
• Automatic default printer selection for first printer added
• Comprehensive error handling with user-friendly messages
• File-based configuration storage using existing system
• Clean CLI output with emojis for better UX

## Testing
• 36 total tests passing (21 unit + 15 integration)
• All CLI commands validated with help text verification
• Input validation edge cases covered
• Error conditions properly tested

## Changes
• Extended main.rs with new CLI subcommands and handlers
• Added validation functions for all input types
• Enhanced config module with dead_code annotations for future features
• Separated tests from implementation per best practices
• Applied clippy fixes for modern string formatting

All commands work without compilation warnings and provide clear feedback to users.